### PR TITLE
Improving Makefile help menu

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-DESC_COLOR = \033[32m
 COMMAND_COLOR = \033[36m
-CLEAR_COLOR = \033[0m
+DESC_COLOR    = \033[32m
+CLEAR_COLOR   = \033[0m
 
 .PHONY: help
 help: ## prints this message ## 

--- a/Makefile
+++ b/Makefile
@@ -1,29 +1,29 @@
-help:
+DESC_COLOR = \033[32m
+COMMAND_COLOR = \033[36m
+CLEAR_COLOR = \033[0m
+
+.PHONY: help
+help: ## prints this message ## 
 	@echo ""; \
 	echo "Usage: make <command>"; \
 	echo ""; \
 	echo "where <command> is one of the following:"; \
 	echo ""; \
-	echo "\thelp\tPrints this message"; \
-	echo ""; \
-	echo "\tstart\tdocker-compose up --build"; \
-	echo "\t\t(starts the minecraft server)"; \
-	echo ""; \
-	echo "\tstop\tdocker-compose stop --rmi all --remove-orphans"; \
-	echo "\t\t(stops and cleans up images, but keeps data)"; \
-	echo ""; \
-	echo "\tattach\tdocker attach mcserver"; \
-	echo "\t\t(attaches to minecraft paper jar for issuing commands)";
-
-start:
+	grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
+	perl -nle '/(.*?): ## (.*?) ## (.*$$)/; if ($$3 eq "") { printf ( "$(COMMAND_COLOR)%-20s$(DESC_COLOR)%s$(CLEAR_COLOR)\n\n", $$1, $$2) } else { printf ( "$(COMMAND_COLOR)%-20s$(DESC_COLOR)%s$(CLEAR_COLOR)\n%-20s%s\n\n", $$1, $$2, " ", $$3) }';
+	
+.PHONY: start
+start: ## docker-compose up --build ## (starts the minecraft server)
 	@echo "Starting Minecraft Server..."; \
 	docker-compose up -d --build;
 
-stop:
+.PHONY: stop
+stop: ## docker-compose stop --rmi all --remove-orphans: ## (stops and cleans up images, but keeps data)
 	@echo "Stopping Minecraft Server and cleaning up..."; \
 	docker-compose down --rmi all --remove-orphans;
 
-attach:
+.PHONY: attach
+attach: ## docker attach mcserver ## (attaches to minecraft paper jar for issuing commands)
 	@echo "Attaching to Minecraft..."; \
 	echo "Ctrl-C stops minecraft and exits"; \
 	echo "Ctrl-P Ctrl-Q only exits"; \


### PR DESCRIPTION
The `Makefile` is now much more dynamic so if commands are added in the future, the "help" menu will update automatically based on the comments.

If a command is added in the Makefile like so:
```Makefile
.PHONY: run
run: ## My description ## (additional notes)
	@echo "My run command";
``` 

It will neatly be added to the list like so:

![image](https://user-images.githubusercontent.com/4381907/105066540-86285c00-5a44-11eb-97f0-197689860bf5.png)