### PR TITLE
Java 16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ########################################################
 ############## We use a java base image ################
 ########################################################
-FROM openjdk:11 AS build
+FROM openjdk:16-alpine AS build
 
 MAINTAINER Marc Tönsing <marc@marc.tv>
 
@@ -14,7 +14,7 @@ WORKDIR /opt/minecraft
 ADD ${PAPERSPIGOT_CI_URL} paperclip.jar
 
 # Run paperclip and obtain patched jar
-RUN /usr/local/openjdk-11/bin/java -jar /opt/minecraft/paperclip.jar; exit 0
+RUN /opt/openjdk-16/bin/java -jar /opt/minecraft/paperclip.jar; exit 0
 
 # Copy built jar
 RUN mv /opt/minecraft/cache/patched*.jar paperspigot.jar
@@ -22,7 +22,7 @@ RUN mv /opt/minecraft/cache/patched*.jar paperspigot.jar
 ########################################################
 ############## Running environment #####################
 ########################################################
-FROM openjdk:11 AS runtime
+FROM openjdk:16-alpine AS runtime
 
 # Working directory
 WORKDIR /data
@@ -53,16 +53,14 @@ ENV JAVAFLAGS=$java_flags
 
 WORKDIR /data
 
-COPY /docker-entrypoint.sh /usr/local/bin/
-RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+COPY /docker-entrypoint.sh /opt/minecraft
+RUN chmod +x /opt/minecraft/docker-entrypoint.sh
 
 # Install gosu
 RUN set -eux; \
-	apt-get update; \
-	apt-get install -y gosu; \
-	rm -rf /var/lib/apt/lists/*; \
-# verify that the binary works
-	gosu nobody true
+	apk update; \
+	apk add --no-cache su-exec;
 
 # Entrypoint
-ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
+ENTRYPOINT ["/opt/minecraft/docker-entrypoint.sh"]
+

--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ docker run --rm \
 
 You can get the desired UID/GID (xxx) with the ID command (id username) then add the following to your docker run command:
 
-```-e PUID=xxx
+```sh
+-e PUID=xxx
 -e PGID=xxx
 ```
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 set -e
 
 DOCKER_USER='dockeruser'
@@ -11,8 +11,8 @@ if ! id "$DOCKER_USER" >/dev/null 2>&1; then
     GROUP_ID=${PGID:-9001}
     echo "Starting with $USER_ID:$GROUP_ID (UID:GID)"
 
-    groupadd -f -g $GROUP_ID $DOCKER_GROUP
-    useradd --shell /bin/bash -u $USER_ID -g $GROUP_ID -o -c "" -m $DOCKER_USER
+    addgroup -g $GROUP_ID $DOCKER_GROUP
+    adduser -s /bin/sh -u $USER_ID -G $DOCKER_GROUP -D $DOCKER_USER
 
     chown -vR $USER_ID:$GROUP_ID /opt/minecraft
     chmod -vR ug+rwx /opt/minecraft
@@ -20,4 +20,4 @@ if ! id "$DOCKER_USER" >/dev/null 2>&1; then
 fi
 
 export HOME=/home/$DOCKER_USER
-exec gosu $DOCKER_USER /usr/local/openjdk-11/bin/java -jar -Xms$MEMORYSIZE -Xmx$MEMORYSIZE $JAVAFLAGS /opt/minecraft/paperspigot.jar --nojline nogui
+exec su-exec $DOCKER_USER /opt/openjdk-16/bin/java -jar -Xms$MEMORYSIZE -Xmx$MEMORYSIZE $JAVAFLAGS /opt/minecraft/paperspigot.jar --nojline nogui


### PR DESCRIPTION
It looks like 1.17 will require Java 16, so I made some changes to the container to get that support rolling now. 

The plugins I use have finally updated to support it, so on Java 16 everything started up, and I was able to access the server (through Geyser/Floodgate). 

I haven't tested much beyond that, yet. 