### PR TITLE
Don't use openjdk17-ae

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ########################################################
 ############## We use a java base image ################
 ########################################################
-FROM openjdk:17-alpine AS build
+FROM azul/zulu-openjdk-alpine:17-jre AS build
 RUN apk --no-cache add curl
 
 LABEL Marc Tönsing <marc@marc.tv>
@@ -23,7 +23,7 @@ RUN /opt/openjdk-17/bin/java -Dpaperclip.patchonly=true -jar /opt/minecraft/pape
 ########################################################
 ############## Running environment #####################
 ########################################################
-FROM openjdk:17-alpine AS runtime
+FROM azul/zulu-openjdk-alpine:17-jre AS runtime
 
 # Working directory
 WORKDIR /data

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN chmod +x /getpaperserver.sh
 RUN /getpaperserver.sh ${version}
 
 # Run paperclip and obtain patched jar
-RUN /opt/openjdk-17/bin/java -Dpaperclip.patchonly=true -jar /opt/minecraft/paperclip.jar; exit 0
+RUN java -Dpaperclip.patchonly=true -jar /opt/minecraft/paperclip.jar; exit 0
 
 ########################################################
 ############## Running environment #####################

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -20,4 +20,4 @@ if ! id "$DOCKER_USER" >/dev/null 2>&1; then
 fi
 
 export HOME=/home/$DOCKER_USER
-exec su-exec $DOCKER_USER /opt/openjdk-17/bin/java -jar -Xms$MEMORYSIZE -Xmx$MEMORYSIZE $JAVAFLAGS /opt/minecraft/paperspigot.jar --nojline nogui
+exec su-exec $DOCKER_USER java -jar -Xms$MEMORYSIZE -Xmx$MEMORYSIZE $JAVAFLAGS /opt/minecraft/paperspigot.jar --nojline nogui


### PR DESCRIPTION
The container with the tag 1.18 crashed on me due to this known error: https://github.com/PaperMC/Paper/issues/7062 

The early access version of openjdk17 used in openjdk:17-apline does not include all the features that exist in the release version.

I use the jre image from azul zulu in my pull request. This has the additional advantage of a smaller image.

Fixes: https://github.com/mtoensing/Docker-Minecraft-PaperMC-Server/issues/34#issuecomment-988926588