### PR TITLE
Update to 1.19

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN apk add curl jq
 
 LABEL Marc Tönsing <marc@marc.tv>
 
-ARG version=1.18.2
+ARG version=1.19
 
 
 ########################################################

--- a/getpaperserver.sh
+++ b/getpaperserver.sh
@@ -1,8 +1,8 @@
 # original script by https://github.com/TheRemote/RaspberryPiMinecraft/blob/master/SetupMinecraft.sh
 # modified with jq 
 Version=$1
-BuildJSON=$(curl -H "Accept-Encoding: identity" -H "Accept-Language: en" -L -A "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4.212 Safari/537.36" https://papermc.io/api/v2/projects/paper/versions/$Version)
-Build=$(echo "$BuildJSON" |     jq .builds[-1])
+BuildJSON=$(curl -H "Accept-Encoding: identity" -H "Accept-Language: en" -L -A "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4.212 Safari/537.36" https://papermc.io/api/v2/projects/paper/versions/$Version/builds)
+Build=$(echo "$BuildJSON" |     jq '[.builds[] | select(.channel == "default")][-1].build')
 curl -H "Accept-Encoding: identity" -H "Accept-Language: en" -L -A "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4.212 Safari/537.36" -o paperclip.jar "https://papermc.io/api/v2/projects/paper/versions/$Version/builds/$Build/downloads/paper-$Version-$Build.jar"
 echo -----------------
 echo $1#$Build


### PR DESCRIPTION
Hi,

Update for 1.19 for Paper dropped. This PR updates the build version to 1.19 and also updates the build number lookup to only use `default` channel builds as advised in their [forum post](https://forums.papermc.io/threads/paper-1-19.344/):

> For future updates, we will no longer provide any early experimental builds on Discord, instead using the experimental channel in our downloads API. This means that you will need to distinguish between channels in your scripts to avoid getting highly experimental and potentially breaking versions. Please adjust your download scripts accordingly. Experimental builds marked as such will be available to download on our homepage as well. 