### PR TITLE
Add MAX and MIN memory option

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,9 +49,14 @@ VOLUME "/data"
 EXPOSE 25565/tcp
 EXPOSE 25565/udp
 
-# Set memory size
-ARG memory_size=1G
-ENV MEMORYSIZE=$memory_size
+# Set min memory size
+ARG memory_size_min=1G
+ENV MEMORYSIZEMIN=$memory_size_min
+
+# Set max memory size
+ARG memory_size_max=1G
+ENV MEMORYSIZEMAX=$memory_size_max
+
 
 # Set Java Flags
 ARG java_flags="-Dlog4j2.formatMsgNoLookups=true -XX:+UseG1GC -XX:+ParallelRefProcEnabled -XX:MaxGCPauseMillis=200 -XX:+UnlockExperimentalVMOptions -XX:+DisableExplicitGC -XX:+AlwaysPreTouch -XX:G1NewSizePercent=30 -XX:G1MaxNewSizePercent=40 -XX:G1HeapRegionSize=8M -XX:G1ReservePercent=20 -XX:G1HeapWastePercent=5 -XX:G1MixedGCCountTarget=4 -XX:InitiatingHeapOccupancyPercent=15 -XX:G1MixedGCLiveThresholdPercent=90 -XX:G1RSetUpdatingPauseTimePercent=5 -XX:SurvivorRatio=32 -XX:+PerfDisableSharedMem -XX:MaxTenuringThreshold=1 -Dusing.aikars.flags=mcflags.emc.gs -Dcom.mojang.eula.agree=true"

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Docker Minecraft PaperMC server for 1.19, 1.18, 1.17 for AMD64 and ARM64 platfor
 ## Quick Start
 
 ```sh
-docker run --rm --name mcserver -e MEMORYSIZE='1G' -v /home/joe/mcserver:/data:rw -p 25565:25565 -i marctv/minecraft-papermc-server:latest
+docker run --rm --name mcserver -e MEMORYSIZEMAX='1G' -v /home/joe/mcserver:/data:rw -p 25565:25565 -i marctv/minecraft-papermc-server:latest
 ```
 
 The server will generate all data including the world and config files in `/home/joe/mcserver`. Change that to an existing folder.
@@ -89,7 +89,8 @@ make help      # prints a help message
 
 ## Environment variables
 
-MEMORYSIZE = 1G
+MEMORYSIZEMIN = 1G <br>
+MEMORYSIZEMAX = 1G
 
 Not more than 70% of your RAM for your container. This is important. Because this is the RAM, your Minecraft Server will use within the container WITHOUT the operating system.
 
@@ -167,7 +168,7 @@ mkdir mcserver
 docker run -d \
 --restart unless-stopped \
 --name mcserver \
--e MEMORYSIZE='1G' \
+-e MEMORYSIZEMAX='1G' \
 -e PAPERMC_FLAGS='' \
 -v /home/pi/mcserver:/data:rw \
 -p 25565:25565 \

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,7 +5,7 @@ services:
     restart: always
     container_name: "mcserver"
     environment:
-      MEMORYSIZE: "1G"
+      MEMORYSIZEMAX: "1G"
       PAPERMC_FLAGS: ""
     volumes:
       - "/home/pi/mcserver:/data:rw"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -24,4 +24,4 @@ if ! id "$DOCKER_USER" >/dev/null 2>&1; then
 fi
 
 export HOME=/home/$DOCKER_USER
-exec gosu $DOCKER_USER:$DOCKER_GROUP java -jar -Xms$MEMORYSIZE -Xmx$MEMORYSIZE $JAVAFLAGS /opt/minecraft/paperspigot.jar $PAPERMC_FLAGS nogui
+exec gosu $DOCKER_USER:$DOCKER_GROUP java -jar -Xms$MEMORYSIZEMIN -Xmx$MEMORYSIZEMAX $JAVAFLAGS /opt/minecraft/paperspigot.jar $PAPERMC_FLAGS nogui


### PR DESCRIPTION
**Pull Request Title:** Add environment variables for configuring Minecraft server memory usage

**Pull Request Description:**
This pull request adds two new environment variables to the Dockerfile, providing the ability to configure the maximum and minimum memory usage for a Minecraft server. This feature allows users to easily adjust the memory allocation based on their server's requirements.

**Changes Made:**
- Added two new environment variables, `MEMORYSIZEMIN` and `MEMORYSIZEMAX`, to the Dockerfile.
- Updated the Dockerfile to utilize the new environment variables in the appropriate sections.
- Documented the usage of the new environment variables in the Dockerfile comments and in the README.md.

**Usage Example:**
To set the minimum memory usage to 1GB and the maximum memory usage to 4GB, you can modify the environment variables in your docker-compose.yml file as follows:

```yaml
version: "3.9"
services:
  minecraft:
    image: "marctv/minecraft-papermc-server:latest"
    restart: always
    container_name: "mcserver"
    environment:
      - MEMORYSIZEMIN=1G
      - MEMORYSIZEMAX=4G
```

Please review and merge this pull request. Thank you!