### PR TITLE
Drop-in compatability with itzg/minecraft-server on Docker hub & minor cleanup

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -1,9 +1,9 @@
 name: Build and push
 
-on: 
+on:
   push:
     branches:
-      - 'latest'
+      - "latest"
   schedule:
     - cron: "0 */12 * * *"
 
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           # Ensure we always use the 'latest' branch for scheduled and manual triggers
-          ref: 'latest'
+          ref: "latest"
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
@@ -32,14 +32,14 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
-      
+
       - name: Log in to the Container registry
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      
+
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v5
@@ -50,7 +50,7 @@ jobs:
           tags: |
             type=raw,value=1.20
             type=raw,value=latest
-      
+
       - name: Build and push Docker images
         uses: docker/build-push-action@v5
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,9 @@ ADD https://github.com/itzg/rcon-cli/releases/download/${RCON_CLI_VER}/rcon-cli_
 RUN tar -x -C /usr/local/bin -f /tmp/rcon-cli.tgz rcon-cli && \
   rm /tmp/rcon-cli.tgz
 
+# Volumes for the external data (Server, World, Config...)
+VOLUME "/data"
+
 # Expose minecraft port
 EXPOSE 25565/tcp
 EXPOSE 25565/udp

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,16 +45,16 @@ ADD https://github.com/itzg/rcon-cli/releases/download/${RCON_CLI_VER}/rcon-cli_
 RUN tar -x -C /usr/local/bin -f /tmp/rcon-cli.tgz rcon-cli && \
   rm /tmp/rcon-cli.tgz
 
-# Volumes for the external data (Server, World, Config...)
-VOLUME "/data"
-
 # Expose minecraft port
 EXPOSE 25565/tcp
 EXPOSE 25565/udp
 
 # Set memory size
-ARG memory_size=1G
-ENV MEMORYSIZE=$memory_size
+ENV MEMORY=1G
+ENV INIT_MEMORY=$MEMORY
+ENV MAX_MEMORY=$MEMORY
+# Backwards compatible env usage
+ENV MEMORYSIZE=$MEMORY
 
 # Set Java Flags
 ARG java_flags="-Dlog4j2.formatMsgNoLookups=true -XX:+UseG1GC -XX:+ParallelRefProcEnabled -XX:MaxGCPauseMillis=200 -XX:+UnlockExperimentalVMOptions -XX:+DisableExplicitGC -XX:+AlwaysPreTouch -XX:G1NewSizePercent=30 -XX:G1MaxNewSizePercent=40 -XX:G1HeapRegionSize=8M -XX:G1ReservePercent=20 -XX:G1HeapWastePercent=5 -XX:G1MixedGCCountTarget=4 -XX:InitiatingHeapOccupancyPercent=15 -XX:G1MixedGCLiveThresholdPercent=90 -XX:G1RSetUpdatingPauseTimePercent=5 -XX:SurvivorRatio=32 -XX:+PerfDisableSharedMem -XX:MaxTenuringThreshold=1 -Dusing.aikars.flags=mcflags.emc.gs -Dcom.mojang.eula.agree=true"

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,11 +24,11 @@ FROM eclipse-temurin:21-jre AS runtime
 ARG TARGETARCH
 # Install gosu
 RUN set -eux; \
- apt-get update; \
- apt-get install -y gosu; \
- rm -rf /var/lib/apt/lists/*; \
-# verify that the binary works
- gosu nobody true
+  apt-get update; \
+  apt-get install -y gosu; \
+  rm -rf /var/lib/apt/lists/*; \
+  # verify that the binary works
+  gosu nobody true
 
 # Install webp (e.g. for Dynmap) Might not be available on ARM (RPI)
 RUN apt-get update && apt-get install -y webp

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Docker Minecraft PaperMC server for 1.20, 1.19, 1.18, 1.17 for AMD64 and ARM64 p
 ## Quick Start
 
 ```sh
-docker run --name mcserver -e MEMORYSIZE='1G' -v /home/joe/mcserver:/data:rw -p 25565:25565 -i marctv/minecraft-papermc-server:latest
+docker run --name mcserver -e MEMORY='1G' -v /home/joe/mcserver:/data:rw -p 25565:25565 -i marctv/minecraft-papermc-server:latest
 ```
 
 The server will generate all data including the world and config files in `/home/joe/mcserver`. Change that to an existing folder.
@@ -17,7 +17,7 @@ The server will generate all data including the world and config files in `/home
 docker run -d \
   --name mcserver \
   --restart=unless-stopped \
-  -e MEMORYSIZE="1G" \
+  -e MEMORY="1G" \
   -p 25565:25565/tcp \
   -p 25565:25565/udp \
   -v /home/docker/mcserver:/data:rw \
@@ -33,7 +33,7 @@ services:
     restart: always
     container_name: "mcserver"
     environment:
-      MEMORYSIZE: "1G"
+      MEMORY: "1G"
       PAPERMC_FLAGS: ""
     volumes:
       - minecraftserver:/data
@@ -123,7 +123,7 @@ make help      # prints a help message
 
 ## Environment variables
 
-MEMORYSIZE = 1G
+MEMORY = 1G
 
 Not more than 70% of your RAM for your container. This is important. Because this is the RAM, your Minecraft Server will use within the container WITHOUT the operating system.
 
@@ -205,7 +205,7 @@ mkdir mcserver
 docker run -d \
 --restart unless-stopped \
 --name mcserver \
--e MEMORYSIZE='1G' \
+-e MEMORY='1G' \
 -e PAPERMC_FLAGS='' \
 -v /home/pi/mcserver:/data:rw \
 -p 25565:25565 \

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Docker Minecraft PaperMC server for 1.20, 1.19, 1.18, 1.17 for AMD64 and ARM64 platforms. Works on Synology, Raspberry Pi 4 or any other systems that support docker.
 
-[![Build and push](https://github.com/mtoensing/Docker-Minecraft-PaperMC-Server/actions/workflows/dockerimage.yml/badge.svg?branch=master&event=push)](https://github.com/mtoensing/Docker-Minecraft-PaperMC-Server/actions/workflows/dockerimage.yml)
+[![Build and push](https://github.com/mtoensing/Docker-Minecraft-PaperMC-Server/actions/workflows/dockerimage.yml/badge.svg)](https://github.com/mtoensing/Docker-Minecraft-PaperMC-Server/actions/workflows/dockerimage.yml)
 
 ## Quick Start
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,7 +5,7 @@ services:
     restart: always
     container_name: "mcserver"
     environment:
-      MEMORYSIZE: "1G"
+      MEMORY: "1G"
       PAPERMC_FLAGS: ""
     volumes:
       - "/home/pi/mcserver:/data:rw"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -5,22 +5,21 @@ DOCKER_USER='dockeruser'
 DOCKER_GROUP='dockergroup'
 
 if ! id "$DOCKER_USER" >/dev/null 2>&1; then
-    echo "First start of the docker container, start initialization process."
+	echo "First start of the docker container, start initialization process."
 
-    UID=${PUID:-1000}
-    GID=${PGID:-1000}
-    echo "Starting with $UID:$GID (UID:GID)"
+	UID=${PUID:-1000}
+	GID=${PGID:-1000}
+	echo "Starting with $UID:$GID (UID:GID)"
 
-    addgroup --gid $GID $DOCKER_GROUP
-    adduser $DOCKER_USER --shell /bin/sh --uid $UID --ingroup $DOCKER_GROUP --disabled-password --gecos ""
+	addgroup --gid $GID $DOCKER_GROUP
+	adduser $DOCKER_USER --shell /bin/sh --uid $UID --ingroup $DOCKER_GROUP --disabled-password --gecos ""
 
-    chown -vR $UID:$GID /opt/minecraft
-    chmod -vR ug+rwx /opt/minecraft
+	chown -vR $UID:$GID /opt/minecraft
+	chmod -vR ug+rwx /opt/minecraft
 
-    if [ "$SKIP_PERM_CHECK" != "true" ]
-    then
-        chown -vR $UID:$GID /data
-    fi
+	if [ "$SKIP_PERM_CHECK" != "true" ]; then
+		chown -vR $UID:$GID /data
+	fi
 fi
 
 export HOME=/home/$DOCKER_USER

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -7,8 +7,8 @@ DOCKER_GROUP='dockergroup'
 if ! id "$DOCKER_USER" >/dev/null 2>&1; then
 	echo "First start of the docker container, start initialization process."
 
-	UID=${PUID:-1000}
-	GID=${PGID:-1000}
+	UID=${PUID:-9001}
+	GID=${PGID:-9001}
 	echo "Starting with $UID:$GID (UID:GID)"
 
 	addgroup --gid $GID $DOCKER_GROUP

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -7,21 +7,21 @@ DOCKER_GROUP='dockergroup'
 if ! id "$DOCKER_USER" >/dev/null 2>&1; then
     echo "First start of the docker container, start initialization process."
 
-    USER_ID=${PUID:-9001}
-    GROUP_ID=${PGID:-9001}
-    echo "Starting with $USER_ID:$GROUP_ID (UID:GID)"
+    UID=${PUID:-1000}
+    GID=${PGID:-1000}
+    echo "Starting with $UID:$GID (UID:GID)"
 
-    addgroup --gid $GROUP_ID $DOCKER_GROUP
-    adduser $DOCKER_USER --shell /bin/sh --uid $USER_ID --ingroup $DOCKER_GROUP --disabled-password --gecos ""
+    addgroup --gid $GID $DOCKER_GROUP
+    adduser $DOCKER_USER --shell /bin/sh --uid $UID --ingroup $DOCKER_GROUP --disabled-password --gecos ""
 
-    chown -vR $USER_ID:$GROUP_ID /opt/minecraft
+    chown -vR $UID:$GID /opt/minecraft
     chmod -vR ug+rwx /opt/minecraft
 
     if [ "$SKIP_PERM_CHECK" != "true" ]
     then
-        chown -vR $USER_ID:$GROUP_ID /data
+        chown -vR $UID:$GID /data
     fi
 fi
 
 export HOME=/home/$DOCKER_USER
-exec gosu $DOCKER_USER:$DOCKER_GROUP java -jar -Xms$MEMORYSIZE -Xmx$MEMORYSIZE $JAVAFLAGS /opt/minecraft/paperspigot.jar $PAPERMC_FLAGS nogui
+exec gosu $DOCKER_USER:$DOCKER_GROUP java -jar -Xms$INIT_MEMORY -Xmx$MAX_MEMORY $JAVAFLAGS /opt/minecraft/paperspigot.jar $PAPERMC_FLAGS nogui


### PR DESCRIPTION
- [x] Maintain backwards compatibility with `MEMORYSIZE`
- [ ] ~Use user `1000` instead of non-standard `9001`~
- [x] Use same environment variables as itzg/minecraft-server (see [their docs](https://docker-minecraft-server.readthedocs.io/en/latest/variables/))
- [x] Various formatting
- [x] Fix broken badge in README