### PR TITLE
Migration from deprecated PaperMC Fill API v2 to Fill API v3

### DIFF
--- a/.github/workflows/build_scheduled.yml
+++ b/.github/workflows/build_scheduled.yml
@@ -73,7 +73,7 @@ jobs:
           BUILD_NUMBER=$(echo "$BUILD_INFO" | jq '.id')
           echo build_number="${BUILD_NUMBER}" >> $GITHUB_OUTPUT
           echo build_type="${BUILD_TYPE}" >> $GITHUB_OUTPUT
-          echo download_url=$(echo "$BUILD_INFO" | jq -r '.downloads.application.url') >> $GITHUB_OUTPUT
+          echo download_url=$(echo "$BUILD_INFO" | jq -r '.downloads."server:default".url') >> $GITHUB_OUTPUT
 
           if [[ $BUILD_TYPE == "stable" && "${{ needs.get_all_versions.outputs.latest }}" == "${{ matrix.versions }}" ]]; then
             echo is_latest="yes" >> $GITHUB_OUTPUT

--- a/.github/workflows/build_scheduled.yml
+++ b/.github/workflows/build_scheduled.yml
@@ -59,10 +59,10 @@ jobs:
           echo "build_beta=$(echo "$BUILD_BETA" | jq '.id')" >> $GITHUB_OUTPUT
           echo "build_alpha=$(echo "$BUILD_ALPHA" | jq '.id')" >> $GITHUB_OUTPUT
 
-          if [[ "$BUILD_STABLE" != "null" ]]; then
+          if [[ -n "$BUILD_STABLE" != "null" ]]; then
             BUILD_INFO="$BUILD_STABLE"
             BUILD_TYPE=stable
-          elif [[ "$BUILD_BETA" != "null" ]]; then
+          elif [[ -n "$BUILD_BETA" != "null" ]]; then
             BUILD_INFO="$BUILD_BETA"
             BUILD_TYPE=experimental
           else

--- a/.github/workflows/build_scheduled.yml
+++ b/.github/workflows/build_scheduled.yml
@@ -48,23 +48,32 @@ jobs:
         run: |
           set -euo pipefail
           BUILDS=$(curl -s -o builds.json https://fill.papermc.io/v3/projects/paper/versions/${{ matrix.versions }}/builds)
-          BUILD_STABLE=$(jq 'first(.[] | select(.channel=="STABLE") | .id)' builds.json)
-          BUILD_BETA=$(jq 'first(.[] | select(.channel=="BETA") | .id)' builds.json)
-          BUILD_ALPHA=$(jq 'first(.[] | select(.channel=="ALPHA") | .id)' builds.json)
-          echo "build_stable=$BUILD_STABLE" >> $GITHUB_OUTPUT
-          echo "build_beta=$BUILD_BETA" >> $GITHUB_OUTPUT
-          echo "build_alpha=$BUILD_ALPHA" >> $GITHUB_OUTPUT
 
-          if  [[ "$BUILD_STABLE" =~ ^[0-9]+$ ]]; then
-            BUILD_NUMBER=$BUILD_STABLE
+          # Extract full objects (not just .id) to access download URL
+          BUILD_STABLE=$(jq 'first(.[] | select(.channel=="STABLE"))' builds.json)
+          BUILD_BETA=$(jq 'first(.[] | select(.channel=="BETA"))' builds.json)
+          BUILD_ALPHA=$(jq 'first(.[] | select(.channel=="ALPHA"))' builds.json)
+
+          # Extract ID for compatibility outputs
+          echo "build_stable=$(echo "$BUILD_STABLE" | jq '.id')" >> $GITHUB_OUTPUT
+          echo "build_beta=$(echo "$BUILD_BETA" | jq '.id')" >> $GITHUB_OUTPUT
+          echo "build_alpha=$(echo "$BUILD_ALPHA" | jq '.id')" >> $GITHUB_OUTPUT
+
+          if [[ "$BUILD_STABLE" != "null" ]]; then
+            BUILD_INFO="$BUILD_STABLE"
             BUILD_TYPE=stable
+          elif [[ "$BUILD_BETA" != "null" ]]; then
+            BUILD_INFO="$BUILD_BETA"
+            BUILD_TYPE=experimental
           else
-            BUILD_NUMBER=${BUILD_BETA:-$BUILD_ALPHA}
+            BUILD_INFO="$BUILD_ALPHA"
             BUILD_TYPE=experimental
           fi
 
+          BUILD_NUMBER=$(echo "$BUILD_INFO" | jq '.id')
           echo build_number="${BUILD_NUMBER}" >> $GITHUB_OUTPUT
           echo build_type="${BUILD_TYPE}" >> $GITHUB_OUTPUT
+          echo download_url=$(echo "$BUILD_INFO" | jq -r '.downloads.application.url') >> $GITHUB_OUTPUT
 
           if [[ $BUILD_TYPE == "stable" && "${{ needs.get_all_versions.outputs.latest }}" == "${{ matrix.versions }}" ]]; then
             echo is_latest="yes" >> $GITHUB_OUTPUT
@@ -96,6 +105,7 @@ jobs:
           echo "build_alpha: ${{ steps.latest_build.outputs.build_alpha }}"
           echo "build_number: ${{ steps.latest_build.outputs.build_number }}"
           echo "build_type: ${{ steps.latest_build.outputs.build_type }}"
+          echo "download_url: ${{ steps.latest_build.outputs.download_url }}"
           echo "is_latest: ${{ steps.latest_build.outputs.is_latest }}"
           echo "is_experimental: ${{ steps.latest_build.outputs.is_experimental }}"
           echo "self_build: ${{ steps.self_build.outputs.self_build }}"
@@ -105,4 +115,4 @@ jobs:
         if: github.event_name == 'workflow_dispatch' || steps.latest_build.outputs.build_number != steps.self_build.outputs.self_build
         with:
           event-type: build_version
-          client-payload: '{"download_version": "${{ matrix.versions }}", "is_latest": "${{ steps.latest_build.outputs.is_latest }}", "is_experimental": "${{ steps.latest_build.outputs.is_experimental }}"}'
+          client-payload: '{"download_version": "${{ matrix.versions }}", "download_url": "${{ steps.latest_build.outputs.download_url }}", "is_latest": "${{ steps.latest_build.outputs.is_latest }}", "is_experimental": "${{ steps.latest_build.outputs.is_experimental }}"}'

--- a/.github/workflows/build_scheduled.yml
+++ b/.github/workflows/build_scheduled.yml
@@ -59,10 +59,10 @@ jobs:
           echo "build_beta=$(echo "$BUILD_BETA" | jq '.id')" >> $GITHUB_OUTPUT
           echo "build_alpha=$(echo "$BUILD_ALPHA" | jq '.id')" >> $GITHUB_OUTPUT
 
-          if [[ -n "$BUILD_STABLE" != "null" ]]; then
+          if [[ -n "$BUILD_STABLE" && "$BUILD_STABLE" != "null" ]]; then
             BUILD_INFO="$BUILD_STABLE"
             BUILD_TYPE=stable
-          elif [[ -n "$BUILD_BETA" != "null" ]]; then
+            if [[ -n "$BUILD_BETA" && "$BUILD_BETA" != "null" ]]; then
             BUILD_INFO="$BUILD_BETA"
             BUILD_TYPE=experimental
           else

--- a/.github/workflows/build_scheduled.yml
+++ b/.github/workflows/build_scheduled.yml
@@ -1,4 +1,4 @@
-name: 'build scheduled'
+name: "build scheduled"
 
 on:
   workflow_dispatch:
@@ -16,10 +16,11 @@ jobs:
         id: get_versions
         run: |
           set -euo pipefail
-          curl -s -o versions.json "https://api.papermc.io/v2/projects/paper"
-          # compute newest unstable (pre/rc etc.) and newest stable (strict semver x.y.z)
-          LATEST_STABLE=$(jq -r '[.versions[] | select(test("^[0-9]+\\.[0-9]+\\.[0-9]+$"))] | last' versions.json)
-          LATEST_UNSTABLE=$(jq -r '[.versions[] | select(test("^[0-9]+\\.[0-9]+\\.[0-9]+$") | not)] | last' versions.json)
+          curl -s -o versions.json "https://fill.papermc.io/v3/projects/paper"
+          # compute newest unstable (pre/rc etc.) and newest stable (strict semver x.y.z) from latest family
+          LATEST_FAMILY=$(jq -r '.versions | keys_unsorted | first' versions.json)
+          LATEST_STABLE=$(jq -r --arg family "$LATEST_FAMILY" '[.versions[$family][] | select(test("^[0-9]+[.][0-9]+[.][0-9]+$"))] | first' versions.json)
+          LATEST_UNSTABLE=$(jq -r --arg family "$LATEST_FAMILY" '[.versions[$family][] | select(test("^[0-9]+[.][0-9]+[.][0-9]+$") | not)] | first' versions.json)
           # build order: newest unstable first, then latest stable
           VERSIONS=$(jq -cn --arg u "$LATEST_UNSTABLE" --arg s "$LATEST_STABLE" '[ $u, $s ] | map(select(. != null and . != ""))')
 
@@ -46,20 +47,22 @@ jobs:
         id: latest_build
         run: |
           set -euo pipefail
-          BUILDS=$(curl -s -o builds.json https://api.papermc.io/v2/projects/paper/versions/${{ matrix.versions }}/builds)
-          BUILD_STABLE=$(jq 'last(.builds[] | select(.channel=="default")).build' builds.json)
-          BUILD_EXPERIMENTAL=$(jq 'last(.builds[] | select(.channel=="experimental")).build' builds.json)
+          BUILDS=$(curl -s -o builds.json https://fill.papermc.io/v3/projects/paper/versions/${{ matrix.versions }}/builds)
+          BUILD_STABLE=$(jq 'first(.[] | select(.channel=="STABLE") | .id)' builds.json)
+          BUILD_BETA=$(jq 'first(.[] | select(.channel=="BETA") | .id)' builds.json)
+          BUILD_ALPHA=$(jq 'first(.[] | select(.channel=="ALPHA") | .id)' builds.json)
           echo "build_stable=$BUILD_STABLE" >> $GITHUB_OUTPUT
-          echo "build_experimental=$BUILD_EXPERIMENTAL" >> $GITHUB_OUTPUT
-          
+          echo "build_beta=$BUILD_BETA" >> $GITHUB_OUTPUT
+          echo "build_alpha=$BUILD_ALPHA" >> $GITHUB_OUTPUT
+
           if  [[ "$BUILD_STABLE" =~ ^[0-9]+$ ]]; then
             BUILD_NUMBER=$BUILD_STABLE
             BUILD_TYPE=stable
           else
-            BUILD_NUMBER=$BUILD_EXPERIMENTAL
+            BUILD_NUMBER=${BUILD_BETA:-$BUILD_ALPHA}
             BUILD_TYPE=experimental
           fi
-          
+
           echo build_number="${BUILD_NUMBER}" >> $GITHUB_OUTPUT
           echo build_type="${BUILD_TYPE}" >> $GITHUB_OUTPUT
 
@@ -68,7 +71,7 @@ jobs:
           else
             echo is_latest="no" >> $GITHUB_OUTPUT
           fi
-          
+
           if [[ $BUILD_TYPE == "experimental" ]]; then
             echo is_experimental="yes" >> $GITHUB_OUTPUT
           else
@@ -89,7 +92,8 @@ jobs:
           echo "latest: ${{ needs.get_all_versions.outputs.latest }}"
           echo "version: ${{ matrix.versions }}"
           echo "build_stable: ${{ steps.latest_build.outputs.build_stable }}"
-          echo "build_experimental: ${{ steps.latest_build.outputs.build_experimental }}"
+          echo "build_beta: ${{ steps.latest_build.outputs.build_beta }}"
+          echo "build_alpha: ${{ steps.latest_build.outputs.build_alpha }}"
           echo "build_number: ${{ steps.latest_build.outputs.build_number }}"
           echo "build_type: ${{ steps.latest_build.outputs.build_type }}"
           echo "is_latest: ${{ steps.latest_build.outputs.is_latest }}"

--- a/.github/workflows/build_scheduled.yml
+++ b/.github/workflows/build_scheduled.yml
@@ -62,7 +62,7 @@ jobs:
           if [[ -n "$BUILD_STABLE" && "$BUILD_STABLE" != "null" ]]; then
             BUILD_INFO="$BUILD_STABLE"
             BUILD_TYPE=stable
-            if [[ -n "$BUILD_BETA" && "$BUILD_BETA" != "null" ]]; then
+          elif [[ -n "$BUILD_BETA" && "$BUILD_BETA" != "null" ]]; then
             BUILD_INFO="$BUILD_BETA"
             BUILD_TYPE=experimental
           else

--- a/.github/workflows/build_version.yml
+++ b/.github/workflows/build_version.yml
@@ -51,7 +51,7 @@ jobs:
           BUILD_NUMBER=$(echo "$BUILD_INFO" | jq '.id')
           echo build_number="${BUILD_NUMBER}" >> $GITHUB_OUTPUT
           echo build_type="${BUILD_TYPE}" >> $GITHUB_OUTPUT
-          echo download_url=$(echo "$BUILD_INFO" | jq -r '.downloads.application.url') >> $GITHUB_OUTPUT
+          echo download_url=$(echo "$BUILD_INFO" | jq -r '.downloads."server:default".url') >> $GITHUB_OUTPUT
           echo build_url=https://fill.papermc.io/v3/projects/paper/versions/${{ env.BASE_VERSION }}/builds/${BUILD_NUMBER} >> $GITHUB_OUTPUT
 
       - name: show version infos

--- a/.github/workflows/build_version.yml
+++ b/.github/workflows/build_version.yml
@@ -37,10 +37,10 @@ jobs:
           BUILD_BETA=$(jq 'first(.[] | select(.channel=="BETA"))' builds.json)
           BUILD_ALPHA=$(jq 'first(.[] | select(.channel=="ALPHA"))' builds.json)
 
-          if [[ "$BUILD_STABLE" != "null" ]]; then
+          if [[ -n "$BUILD_STABLE" && "$BUILD_STABLE" != "null" ]]; then
             BUILD_INFO="$BUILD_STABLE"
             BUILD_TYPE=stable
-          elif [[ "$BUILD_BETA" != "null" ]]; then
+          elif [[ -n "$BUILD_BETA" && "$BUILD_BETA" != "null" ]]; then
             BUILD_INFO="$BUILD_BETA"
             BUILD_TYPE=experimental
           else

--- a/.github/workflows/build_version.yml
+++ b/.github/workflows/build_version.yml
@@ -1,17 +1,17 @@
-name: 'build version'
-run-name: 'build for version ${{ inputs.download_version }}${{ github.event.client_payload.download_version }}'
+name: "build version"
+run-name: "build for version ${{ inputs.download_version }}${{ github.event.client_payload.download_version }}"
 
 on:
   workflow_dispatch:
     inputs:
       download_version:
-        description: 'papermc server version'
+        description: "papermc server version"
         required: true
-        default: '1.20.6'
+        default: "1.20.6"
 
   # Allows you to trigger this workflow from another workflow
   repository_dispatch:
-    types: [ build_version ]
+    types: [build_version]
 
 jobs:
   buid_version:
@@ -30,22 +30,23 @@ jobs:
       - name: get build
         id: get_build
         run: |
-          BUILDS=$(curl -s -o builds.json https://api.papermc.io/v2/projects/paper/versions/${{ env.BASE_VERSION }}/builds)
-          BUILD_STABLE=$(jq 'last(.builds[] | select(.channel=="default")).build' builds.json)
-          BUILD_EXPERIMENTAL=$(jq 'last(.builds[] | select(.channel=="experimental")).build' builds.json)
-          
+          BUILDS=$(curl -s -o builds.json https://fill.papermc.io/v3/projects/paper/versions/${{ env.BASE_VERSION }}/builds)
+          BUILD_STABLE=$(jq 'first(.[] | select(.channel=="STABLE") | .id)' builds.json)
+          BUILD_BETA=$(jq 'first(.[] | select(.channel=="BETA") | .id)' builds.json)
+          BUILD_ALPHA=$(jq 'first(.[] | select(.channel=="ALPHA") | .id)' builds.json)
+
           if  [[ "$BUILD_STABLE" =~ ^[0-9]+$ ]]; then
             BUILD_NUMBER=$BUILD_STABLE
             BUILD_TYPE=stable
           else
-            BUILD_NUMBER=$BUILD_EXPERIMENTAL
+            BUILD_NUMBER=${BUILD_BETA:-$BUILD_ALPHA}
             BUILD_TYPE=experimental
           fi
-          
+
           echo build_number="${BUILD_NUMBER}" >> $GITHUB_OUTPUT
           echo build_type="${BUILD_TYPE}" >> $GITHUB_OUTPUT
-          echo build_url=https://api.papermc.io/v2/projects/paper/versions/${{ env.BASE_VERSION }}/builds/${BUILD_NUMBER} >> $GITHUB_OUTPUT
-          echo download_url="https://api.papermc.io/v2/projects/paper/versions/${{ env.BASE_VERSION }}/builds/${BUILD_NUMBER}/downloads/paper-${{ env.BASE_VERSION }}-${BUILD_NUMBER}.jar" >> $GITHUB_OUTPUT
+          echo build_url=https://fill.papermc.io/v3/projects/paper/versions/${{ env.BASE_VERSION }}/builds/${BUILD_NUMBER} >> $GITHUB_OUTPUT
+          echo download_url="https://fill.papermc.io/v3/projects/paper/versions/${{ env.BASE_VERSION }}/builds/${BUILD_NUMBER}/downloads/paper-${{ env.BASE_VERSION }}-${BUILD_NUMBER}.jar" >> $GITHUB_OUTPUT
 
       - name: show version infos
         run: |

--- a/.github/workflows/build_version.yml
+++ b/.github/workflows/build_version.yml
@@ -31,22 +31,28 @@ jobs:
         id: get_build
         run: |
           BUILDS=$(curl -s -o builds.json https://fill.papermc.io/v3/projects/paper/versions/${{ env.BASE_VERSION }}/builds)
-          BUILD_STABLE=$(jq 'first(.[] | select(.channel=="STABLE") | .id)' builds.json)
-          BUILD_BETA=$(jq 'first(.[] | select(.channel=="BETA") | .id)' builds.json)
-          BUILD_ALPHA=$(jq 'first(.[] | select(.channel=="ALPHA") | .id)' builds.json)
 
-          if  [[ "$BUILD_STABLE" =~ ^[0-9]+$ ]]; then
-            BUILD_NUMBER=$BUILD_STABLE
+          # Extract full objects (not just .id) to access download URL
+          BUILD_STABLE=$(jq 'first(.[] | select(.channel=="STABLE"))' builds.json)
+          BUILD_BETA=$(jq 'first(.[] | select(.channel=="BETA"))' builds.json)
+          BUILD_ALPHA=$(jq 'first(.[] | select(.channel=="ALPHA"))' builds.json)
+
+          if [[ "$BUILD_STABLE" != "null" ]]; then
+            BUILD_INFO="$BUILD_STABLE"
             BUILD_TYPE=stable
+          elif [[ "$BUILD_BETA" != "null" ]]; then
+            BUILD_INFO="$BUILD_BETA"
+            BUILD_TYPE=experimental
           else
-            BUILD_NUMBER=${BUILD_BETA:-$BUILD_ALPHA}
+            BUILD_INFO="$BUILD_ALPHA"
             BUILD_TYPE=experimental
           fi
 
+          BUILD_NUMBER=$(echo "$BUILD_INFO" | jq '.id')
           echo build_number="${BUILD_NUMBER}" >> $GITHUB_OUTPUT
           echo build_type="${BUILD_TYPE}" >> $GITHUB_OUTPUT
+          echo download_url=$(echo "$BUILD_INFO" | jq -r '.downloads.application.url') >> $GITHUB_OUTPUT
           echo build_url=https://fill.papermc.io/v3/projects/paper/versions/${{ env.BASE_VERSION }}/builds/${BUILD_NUMBER} >> $GITHUB_OUTPUT
-          echo download_url="https://fill.papermc.io/v3/projects/paper/versions/${{ env.BASE_VERSION }}/builds/${BUILD_NUMBER}/downloads/paper-${{ env.BASE_VERSION }}-${BUILD_NUMBER}.jar" >> $GITHUB_OUTPUT
 
       - name: show version infos
         run: |


### PR DESCRIPTION
related to #136 

### Problem:
Workflow is using the v2 API which stopped receiving new builds see Message on Discord Server:
```
🌅 Reminder: The Fill v2 downloads service is approaching its end-of-life. Please plan accordingly to transition to the latest version. You can review the full documentation [here](https://docs.papermc.io/misc/downloads-service/).
December 31, 2025: v2 will stop receiving new builds at the end of this year
July 1, 2026: v2 will be disabled and no longer accessible
```
### Changes:

-   **API Endpoint:** Migrated from api.papermc.io/v2 to fill.papermc.io/v3
-   **Build Array:** Builds are returned as a flat array at the root level, no longer nested
-   **Sorting:** Builds are sorted descending (newest first), requiring first() instead of last()
-   **Build Channels:** Replaced default/experimental with explicit STABLE, BETA, and ALPHA channels
-   **Build ID:** Field changed from .build to .id
-   **Download URL:** URLs are now dynamic and must be extracted from .downloads."server:default".url instead of being constructed

### Testing:

- **API parsing:** Validated locally with curl and jq for sample versions
- **build_version:** Works when triggered manually
- **build_schedule:** Complete flow untestable in PR branch due to repository_dispatch using main branch by default